### PR TITLE
AESinkPULSE: fixed stuttering sound on passthrough

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -786,6 +786,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
       m_stats->UpdateSinkDelay(0, samples->pool ? maxFrames : 0);
       return 0;
     }
+    retry=0;
     frames -= written;
     buffer += written*m_sinkFormat.m_frameSize;
     sinkDelay = m_sink->GetDelay();


### PR DESCRIPTION
I had some issues with the pass through sound on my setup. 
This very small patch fixed it.
- don't abort too early with CActiveAESink::OutputSamples - failed: reset the retry count if m_sink->AddPackets was successful

As far as I can tell: AddPackets very often (if not always) returns at least once with zero in CActiveAESink::OutputSamples. 
This behaviour is caused (as you most likely know) by pa_stream_writable_size returning zero as well.

So I think my patch should do no harm.
But of course I don't know how all the other sinks work.

If you need somebody to test out your work on the Pulse audio sink, I'm glad to help.
