### PR TITLE
[ffmpeg/osx] - add --disable-securetransport to configure to prevent …

### DIFF
--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -45,6 +45,7 @@ ifeq ($(OS), osx)
   ffmpg_config += --disable-outdev=sdl
   ffmpg_config += --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd
   ffmpg_config += --target-os=darwin
+  ffmpg_config += --disable-securetransport
 endif
 ifeq ($(findstring arm, $(CPU)), arm)
   ffmpg_config += --enable-pic --disable-armv5te --disable-armv6t2


### PR DESCRIPTION
…linkage against libsecurity_ssl (gnutls provides the functionality - but ffmpeg autodetect fails and tries to do it the appl/libsecurity_ssl way)

verified that https streams still play ...